### PR TITLE
Hotfix: Coyote double naming of assay due to sample sheet change

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -489,7 +489,7 @@ process import_to_coyote {
 		file("${id}.coyote")
 	
 	script:
-		id= "${smpl_id}-fusions"
+		id= "${smpl_id}s"
 		group= 'fusion'
 	
 	"""


### PR DESCRIPTION
Due to recent change in the Samplesheet, the naming in coyote, there is issue in the coyote sample presentation. Rather than having a normal name  i.e "SampleID_fusions" there is new redundant naming - "SampleID_fusion_fusions" . 

I changed to the import_to_coyote to follow the standard convention, and tested it.

